### PR TITLE
New spinner and lock script update

### DIFF
--- a/index.css
+++ b/index.css
@@ -86,6 +86,14 @@ body #a0-lock.a0-theme-default .a0-panel .a0-footer .a0-logo i,
 body #a0-widget .a0-panel .a0-footer .a0-logo i {
   color: white;
 }
+body #a0-lock .a0-panel .a0-spinner .a0-spinner-circle-outer .a0-spinner-circle-inner,
+body #a0-lock.a0-theme-default .a0-panel .a0-spinner .a0-spinner-circle-outer .a0-spinner-circle-inner,
+body #a0-widget .a0-panel .a0-spinner .a0-spinner-circle-outer .a0-spinner-circle-inner {
+  border-top-color: rgba(255, 255, 255, 0.2);
+  border-right-color: rgba(255, 255, 255, 0.2);
+  border-bottom-color: rgba(255, 255, 255, 0.2);
+  border-left-color: #ffffff;
+}
 @media screen and (max-width: 480px) {
   body #a0-lock .a0-popup .a0-overlay,
   body #a0-widget .a0-popup .a0-overlay {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="index.css">
   </head>
   <body>
-    <script src="https://cdn.auth0.com/js/lock-6.min.js"></script>
+    <script src="https://cdn.auth0.com/js/lock-7.min.js"></script>
     <script>
       var lock = new Auth0Lock('0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup', 'mdocs.auth0.com')
 

--- a/index.less
+++ b/index.less
@@ -65,6 +65,12 @@ body #a0-widget {
       color: white;
     }
 
+    .a0-spinner .a0-spinner-circle-outer .a0-spinner-circle-inner {
+      border-top-color: rgba(255,255,255, 0.2);
+      border-right-color: rgba(255,255,255, 0.2);
+      border-bottom-color: rgba(255,255,255, 0.2);
+      border-left-color: rgba(255,255,255, 1);
+    }
   }
 }
 


### PR DESCRIPTION
This is a changes the color of the new spinner added to Lock (see [details](https://github.com/auth0/lock/issues/254)) so it looks good on a dark background. It won't cause any trouble with versions of Lock with the old spinner.

Also updates the Lock script used in the demo page to v7. 

<img width="298" alt="gradient" src="https://cloud.githubusercontent.com/assets/120195/11880962/9fc048d4-a4e2-11e5-94d0-c0510d37f363.png">
